### PR TITLE
feat: add native PHP type declarations to generated properties, getters and setters

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -558,9 +558,27 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     protected function addColumnAttributeDeclaration(string &$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
-        $script .= "
+        $nativeType = $column->getNativeTypeDeclaration();
+
+        if ($nativeType !== null) {
+            if ($column->isPhpPrimitiveType() || $nativeType === 'array') {
+                $typeDeclaration = '?' . $nativeType;
+            } else {
+                $typeDeclaration = '?' . $this->declareClass($nativeType);
+            }
+            $script .= "
+    protected " . $typeDeclaration . " \$" . $clo . " = null;
+";
+        } elseif ($column->isTemporalType()) {
+            $dateTimeClass = $this->getDateTimeClass($column);
+            $script .= "
+    protected ?" . $dateTimeClass . " \$" . $clo . " = null;
+";
+        } else {
+            $script .= "
     protected \$" . $clo . ";
 ";
+        }
     }
 
     /**
@@ -986,12 +1004,14 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
             $format = 'null';
         }
 
+        $dateTimeClass = $this->getDateTimeClass($column);
+
         $script .= "
     " . $visibility . " function get$cfc(?string \$format = " . $format;
         if ($column->isLazyLoad()) {
             $script .= ', ?ConnectionInterface $con = null';
         }
-        $script .= ")
+        $script .= "): string|" . $dateTimeClass . "|null
     {";
     }
 
@@ -1286,7 +1306,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
             $script .= '?ConnectionInterface $con = null';
         }
 
-        $script .= ")
+        $script .= "): ?bool
     {";
     }
 
@@ -1565,8 +1585,17 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
             $script .= '?ConnectionInterface $con = null';
         }
 
-        $script .= ")
+        $nativeType = $column->getNativeTypeDeclaration();
+        if ($nativeType !== null) {
+            if (!$column->isPhpPrimitiveType() && $nativeType !== 'array') {
+                $nativeType = $this->declareClass($nativeType);
+            }
+            $script .= "): ?" . $nativeType . "
     {";
+        } else {
+            $script .= ")
+    {";
+        }
     }
 
     /**
@@ -1849,6 +1878,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         $null = '';
 
         if ($column->getTypeHint()) {
+            // Explicit typeHint from schema XML (FQCN for object columns)
             $typeHint = $column->getTypeHint();
             if ($typeHint !== 'array') {
                 $typeHint = $this->declareClass($typeHint);
@@ -1860,10 +1890,20 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
                 $typeHint = '?' . $typeHint;
                 $null = ' = null';
             }
+        } elseif ($column->isTemporalType()) {
+            $dateTimeClass = $this->getDateTimeClass($column);
+            $typeHint = 'string|int|' . $dateTimeClass . '|null ';
+            $null = ' = null';
+        } elseif (!$column->isEnumType() && !$column->isSetType() && !$column->isBooleanType()) {
+            $nativeType = $column->getNativeTypeDeclaration();
+            if ($nativeType !== null) {
+                $typeHint = '?' . $nativeType . ' ';
+                $null = ' = null';
+            }
         }
 
         $script .= "
-    " . $visibility . " function set$cfc($typeHint\$v$null)
+    " . $visibility . " function set$cfc($typeHint\$v$null): static
     {";
     }
 

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -1657,6 +1657,30 @@ class Column extends MappingModel
     }
 
     /**
+     * Returns the native PHP type declaration keyword for this column.
+     *
+     * Converts PHPDoc-style types to valid PHP type declaration keywords
+     * (e.g. 'boolean' → 'bool', 'double' → 'float').
+     * Returns null for temporal types (handled separately by builders)
+     * and for types that cannot be natively typed (resource, object).
+     *
+     * When a typeHint is explicitly set (e.g. for OBJECT columns), it is
+     * returned directly as a FQCN.
+     */
+    public function getNativeTypeDeclaration(): ?string
+    {
+        if ($this->typeHint !== null) {
+            return $this->typeHint;
+        }
+
+        if ($this->isTemporalType()) {
+            return null;
+        }
+
+        return PropelTypes::getNativeTypeDeclaration($this->getPhpType());
+    }
+
+    /**
      * Returns whether the column PHP native type is primitive type (aka
      * a boolean, an integer, a long, a float, a double or a string).
      *

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -443,6 +443,47 @@ class PropelTypes
     ];
 
     /**
+     * Mapping between Propel PHP native types and PHP type declaration keywords.
+     *
+     * Maps PHPDoc-style types ('boolean', 'double') to valid PHP native type
+     * declaration keywords ('bool', 'float'). Returns null for types that
+     * cannot be expressed as native PHP type declarations (resource, object).
+     *
+     * @var array<string, string|null>
+     */
+    private static array $mappingToNativeTypeDeclarationMap = [
+        'boolean' => 'bool',
+        'int' => 'int',
+        'double' => 'float',
+        'float' => 'float',
+        'string' => 'string',
+        'array' => 'array',
+        'resource' => null,
+        '' => null,
+    ];
+
+    /**
+     * Returns the native PHP type declaration keyword for the given PHP type.
+     *
+     * Converts PHPDoc-style types ('boolean', 'double') to valid PHP type
+     * declaration keywords ('bool', 'float'). Returns null for types that
+     * cannot be natively typed (resource, object).
+     */
+    public static function getNativeTypeDeclaration(string $phpType): ?string
+    {
+        return self::$mappingToNativeTypeDeclarationMap[$phpType] ?? null;
+    }
+
+    /**
+     * Returns whether the given PHP type can be expressed as a native PHP type declaration.
+     */
+    public static function isNativelyTypable(string $phpType): bool
+    {
+        return isset(self::$mappingToNativeTypeDeclarationMap[$phpType])
+            && self::$mappingToNativeTypeDeclarationMap[$phpType] !== null;
+    }
+
+    /**
      * Mapping between mapping types and PDO type constants (for prepared
      * statement settings).
      *


### PR DESCRIPTION

- PropelTypes: new getNativeTypeDeclaration() mapping (boolean→bool, double→float)
- Column: getNativeTypeDeclaration() helper routing to PropelTypes or typeHint
- ObjectBuilder: typed properties (protected ?int $id = null)
- ObjectBuilder: return types on getters (?int, ?string, ?bool, string|DateTime|null)
- ObjectBuilder: param types on primitive setters (?int, ?string, ?float)
- ObjectBuilder: :static return type on all setters
- ENUM/SET/BOOLEAN excluded from setter param typing (permissive internal conversion)